### PR TITLE
Add sticky to headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /database
+.idea

--- a/blocks/content.css
+++ b/blocks/content.css
@@ -9,6 +9,7 @@
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(5px);
+  position: relative;
 }
 
 /* Typography elements */
@@ -21,6 +22,7 @@
   padding-bottom: 0.5rem;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
   position: sticky;
+  top: -2rem;
 }
 
 .content__heading {
@@ -28,8 +30,12 @@
   font-size: 1.5rem;
   border-bottom: 2px solid var(--dark-grey);
   padding-bottom: 0.5rem;
+  padding-top: 0.2rem; /* added a top padding to give a little distance between top of content and this */
   margin: 2rem 0 1rem 0;
-  position: relative;
+  position: sticky;
+  /* has to be a solid color with no alpha otherwise you get passthrough of stacked headers */
+  top: -1.5rem;
+  background-color: #f8f8f8;
 }
 
 .content__heading::before {

--- a/sections/changelog.html
+++ b/sections/changelog.html
@@ -1359,5 +1359,6 @@
       calculations follow official V5 rules for authentic gameplay experience,
       and the modular design allows for easy expansion and customization.
     </p>
+    <br /> <br /> <br /> <br /> <br /><!-- linebreaks added to push header -->
   </div>
 </section>


### PR DESCRIPTION
## Details

This PR makes the headers sticky for scrolling. 

as certain CSS features are not universal at the moment, we can't implement container scroll query in the css to allow to only set the padding and background colour on when it becomes "stuck", which is a shame, but for now that means that they live within the css for the element.

having both `content__title` and `content__header` sticky, means that they stack on each other as they're all within the same parent element. So a content__header stacks on top of the `content_title` "overriding" it

### Other changes
- added line breaks to the end of the changelog so that the "🚀 Upcoming Features" header could override the Version 0.1.0
- added my editor's (phpstorm) config to the git ignore